### PR TITLE
use the latest image hosted in github's container registry

### DIFF
--- a/atlantis-on-aci.sh
+++ b/atlantis-on-aci.sh
@@ -119,7 +119,7 @@ az container create \
     --azure-file-volume-account-key $STORAGE_KEY \
     --azure-file-volume-share-name "atlantis-cert-share" \
     --azure-file-volume-mount-path /mnt/atlantis-certs \
-    --image runatlantis/atlantis:latest \
+    --image ghcr.io/runatlantis/atlantis:latest \
     --os-type Linux \
     --restart-policy OnFailure \
     --cpu 1 \


### PR DESCRIPTION
I noticed that the latest tag on dockerhub is stale, switch to ghcr.io since [that is the one they maintain](https://github.com/runatlantis/atlantis/issues/1926)